### PR TITLE
Clarify that initial sync is with execvp.

### DIFF
--- a/minimal_strace.c
+++ b/minimal_strace.c
@@ -35,12 +35,14 @@ main(int argc, char **argv)
             FATAL("%s", strerror(errno));
         case 0:  /* child */
             ptrace(PTRACE_TRACEME, 0, 0, 0);
+            /* Because we're now a tracee, execvp will block until the parent
+             * attaches and allows us to continue. */
             execvp(argv[1], argv + 1);
             FATAL("%s", strerror(errno));
     }
 
     /* parent */
-    waitpid(pid, 0, 0); // sync with PTRACE_TRACEME
+    waitpid(pid, 0, 0); // sync with execvp
     ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_EXITKILL);
 
     for (;;) {

--- a/xpledge.c
+++ b/xpledge.c
@@ -77,12 +77,14 @@ main(int argc, char **argv)
             FATAL("%s", strerror(errno));
         case 0:  /* child */
             ptrace(PTRACE_TRACEME, 0, 0, 0);
+            /* Because we're now a tracee, execvp will block until the parent
+             * attaches and allows us to continue. */
             execvp(argv[1], argv + 1);
             FATAL("%s", strerror(errno));
     }
 
     /* parent */
-    waitpid(pid, 0, 0); // sync with PTRACE_TRACEME
+    waitpid(pid, 0, 0); // sync with execvp
     ptrace(PTRACE_SETOPTIONS, pid, 0, PTRACE_O_EXITKILL);
 
     for (;;) {


### PR DESCRIPTION
from `man 2 ptrace`:

>  The request
>
>         ptrace(PTRACE_TRACEME, 0, 0, 0);
>
>  turns the calling thread into a tracee.  The thread continues to run
>  (doesn't enter ptrace-stop).

However, the execvp immediately after the PTRACE_TRACEME call *does* block:

> If the PTRACE_O_TRACEEXEC option is not in effect, all successful calls to
> execve(2) by the traced process will cause  it  to  be sent a SIGTRAP signal,
> giving the parent a chance to gain control before the new program begins
> execution.